### PR TITLE
fix encoding error for Python-3.6

### DIFF
--- a/sketch_rnn.py
+++ b/sketch_rnn.py
@@ -67,7 +67,7 @@ def normalize(strokes):
         data.append(seq)
     return data
 
-dataset = np.load(hp.data_location)
+dataset = np.load(hp.data_location, encoding='latin1')
 data = dataset['train']
 data = purify(data)
 data = normalize(data)


### PR DESCRIPTION
Not passing the encoding format to `np.load()` throws error in Python 3.6. This PR fixes the bug.