### PR TITLE
Fix transpose

### DIFF
--- a/sketch_rnn.py
+++ b/sketch_rnn.py
@@ -183,12 +183,12 @@ class DecoderRNN(nn.Module):
             len_out = Nmax+1
         else:
             len_out = 1
-        pi = F.softmax(pi.t().squeeze()).view(len_out,-1,hp.M)
-        sigma_x = torch.exp(sigma_x.t().squeeze()).view(len_out,-1,hp.M)
-        sigma_y = torch.exp(sigma_y.t().squeeze()).view(len_out,-1,hp.M)
-        rho_xy = torch.tanh(rho_xy.t().squeeze()).view(len_out,-1,hp.M)
-        mu_x = mu_x.t().squeeze().contiguous().view(len_out,-1,hp.M)
-        mu_y = mu_y.t().squeeze().contiguous().view(len_out,-1,hp.M)
+        pi = F.softmax(pi.transpose(0, 1).squeeze()).view(len_out,-1,hp.M)
+        sigma_x = torch.exp(sigma_x.transpose(0, 1).squeeze()).view(len_out,-1,hp.M)
+        sigma_y = torch.exp(sigma_y.transpose(0, 1).squeeze()).view(len_out,-1,hp.M)
+        rho_xy = torch.tanh(rho_xy.transpose(0, 1).squeeze()).view(len_out,-1,hp.M)
+        mu_x = mu_x.transpose(0, 1).squeeze().contiguous().view(len_out,-1,hp.M)
+        mu_y = mu_y.transpose(0, 1).squeeze().contiguous().view(len_out,-1,hp.M)
         q = F.softmax(params_pen).view(len_out,-1,3)
         return pi,mu_x,mu_y,sigma_x,sigma_y,rho_xy,q,hidden,cell
 


### PR DESCRIPTION
I think this is introduced in PyTorch 0.4, but transpose now only takes 2D Tensor.